### PR TITLE
Correct type for 'file' in AgentResponse comments

### DIFF
--- a/callAgentService.ts
+++ b/callAgentService.ts
@@ -7,7 +7,7 @@ type AgentRequestPayload = {
 };
 
 type AgentResponse = {
-  reviewId: string;
+  reviewId: ;
   summary: string;
   comments: Array<{
     file: string;


### PR DESCRIPTION
Fix type definition for comments array in AgentResponse.