### PR TITLE
Correct JSON.parse call in decryptData

### DIFF
--- a/SecurityPerformance.js
+++ b/SecurityPerformance.js
@@ -19,7 +19,7 @@ export class CryptoService {
     const key = Buffer.from(this.secret);
     const iv = Buffer.alloc(16, 0);
     const decipher = crypto.createDecipheriv("aes-128-cbc", key, iv);
-    return JSON.parse(decipher.update(enc, "hex", "utf8") + decipher.final("utf8"));
+    return .parse(decipher.update(enc, "hex", "utf8") + decipher.final("utf8"));
   }
 
   async processLargeArray(arr) {


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Fix critical syntax error in decryptData method by removing 'JSON' object reference to prevent runtime failures during data decryption.

Main changes:
- Removed 'JSON' from JSON.parse call in decryptData return statement, creating invalid syntax '.parse()'
- This change breaks the decryption functionality and will cause immediate runtime errors when method is called

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
