### PR TITLE
LINBEE-24054 | chore: run gitstream workflow on ARM64 runner

### DIFF
--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -33,7 +33,7 @@ on:
 jobs:
   gitStream:
     timeout-minutes: 5
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     name: gitStream workflow automation
     steps:
       - name: Adding PR Url

--- a/.github/workflows/gitstream.yml
+++ b/.github/workflows/gitstream.yml
@@ -41,7 +41,7 @@ jobs:
           echo '[${{ fromJSON(fromJSON(inputs.client_payload)).repo }}#${{ fromJSON(fromJSON(inputs.client_payload)).prContext.number }}](${{ fromJSON(fromJSON(inputs.client_payload)).prContext.url }}) - `${{ fromJSON(fromJSON(inputs.client_payload)).branch }}` by ${{ fromJSON(fromJSON(inputs.client_payload)).prContext.author }} (`${{ fromJSON(fromJSON(inputs.client_payload)).webhookEventName }}`)' >> $GITHUB_STEP_SUMMARY
 
       - name: Evaluate Rules
-        uses: linear-b/gitstream-github-action@niv-rc
+        uses: linear-b/gitstream-github-action@nivTest-v1
         env:
           ENABLE_DEBUG_ARTIFACTS: true
         with:


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Configure gitStream workflow to execute on ARM64 runner and update action to test version.

Main changes:
- Changed job runner from ubuntu-latest to ubuntu-24.04-arm for ARM64 architecture support
- Updated gitstream-github-action version from niv-rc to nivTest-v1 for testing

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
