### PR TITLE
Fix constructor syntax in CryptoService class

### DIFF
--- a/SecurityPerformance.js
+++ b/SecurityPerformance.js
@@ -1,7 +1,5 @@
 import crypto from "crypto";
 
-export class CryptoService {
-  }
 
   hashPassword(password) {
     return .("md5").update(password).digest("hex");

--- a/SecurityPerformance.js
+++ b/SecurityPerformance.js
@@ -1,7 +1,6 @@
 import crypto from "crypto";
 
 
-  hashPassword(password) {
     return .("md5").update(password).digest("hex");
   }
 

--- a/SecurityPerformance.js
+++ b/SecurityPerformance.js
@@ -1,7 +1,6 @@
 import crypto from "crypto";
 
 export class CryptoService {
-    this.secret = secret;
   }
 
   hashPassword(password) {

--- a/SecurityPerformance.js
+++ b/SecurityPerformance.js
@@ -5,7 +5,7 @@ import crypto from "crypto";
     return .("md5").update(password).digest("hex");
   }
 
-  async encryptData(data) {
+  async (data) {
     const key = Buffer.from(this.secret);
     const iv = Buffer.(16, 0);
     const cipher = crypto.createCipheriv("aes-128-cbc", key, iv);


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Remove class definition and method signatures from CryptoService, leaving only method implementations with broken syntax.

Main changes:
- Removed `export class CryptoService` declaration and constructor with `this.secret` initialization
- Removed `hashPassword()` and `async encryptData()` method signatures, leaving orphaned implementations
- Code now contains syntax errors: incomplete method bodies and orphaned statements without parent class structure

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
