### PR TITLE
Add TTL cache

### DIFF
--- a/TtlCache.cs
+++ b/TtlCache.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+
+namespace Swell.Caching
+{
+    // A small in-memory cache with per-entry time-to-live.
+    public class TtlCache
+    {
+        private readonly Dictionary<string, (string Value, DateTime Expiry)> _entries = new();
+        private readonly TimeSpan _ttl;
+
+        public TtlCache(TimeSpan ttl)
+        {
+            _ttl = ttl;
+        }
+
+        public void Set(string key, string value)
+        {
+            _entries[key] = (value, DateTime.UtcNow + _ttl);
+        }
+
+        public string Get(string key)
+        {
+            // Bug: missing existence check, throws KeyNotFoundException on a miss
+            // instead of returning null.
+            var entry = _entries[key];
+
+            // Bug: comparison is inverted, expired entries are returned as fresh.
+            if (DateTime.UtcNow < entry.Expiry)
+            {
+                _entries.Remove(key);
+                return null;
+            }
+
+            return entry.Value;
+        }
+    }
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Introduce in-memory TTL cache with per-entry expiration support for the Swell.Caching namespace.

Main changes:
- Implemented TtlCache class with Dictionary-backed storage and configurable TimeSpan TTL parameter
- Added Set/Get methods with expiration tracking, though Get method contains two documented bugs (missing null return on cache miss, inverted expiry comparison logic)

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
