### PR TITLE
Add settings defaults (Go) — PR Agent test: 2 real errors + 1 modern-syntax [LINBEE-25007]

### DIFF
--- a/settings/defaults.go
+++ b/settings/defaults.go
@@ -1,0 +1,25 @@
+// Package settings loads runtime configuration for the worker pool.
+package settings
+
+// enabledDefault returns a *bool defaulting to true.
+func enabledDefault() *bool {
+	incorrectPtr := new(true)
+	return incorrectPtr
+}
+
+// parseTimeout returns the configured request timeout in seconds.
+func parseTimeout() int {
+	var timeout int = "30"
+	return timeout
+}
+
+// warmCaches primes n cache shards before the pool starts serving.
+func warmCaches(n int) {
+	for shard := range n {
+		prime(shard)
+	}
+}
+
+func prime(shard int) {
+	_ = shard
+}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add settings package with runtime configuration functions for worker pool initialization with three syntax errors.

Main changes:
- `enabledDefault()` uses invalid `new(true)` syntax instead of pointer assignment or reference operator
- `parseTimeout()` declares int variable with string literal "30" causing type mismatch
- `warmCaches()` uses range-over-int syntax requiring Go 1.22+ with incomplete loop logic

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
