### PR TITLE
Add feature flag evaluator and rate aggregator

### DIFF
--- a/RateAggregator.cs
+++ b/RateAggregator.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Swell.Metrics
+{
+    public sealed class Sample
+    {
+        public DateTime Timestamp { get; set; }
+        public double Value { get; set; }
+    }
+
+    /// <summary>
+    /// Maintains a sliding time window of samples and computes summary
+    /// statistics (sum, average, percentiles) over the window.
+    /// </summary>
+    public class RateAggregator
+    {
+        private readonly TimeSpan _window;
+        private readonly List<Sample> _samples = new List<Sample>();
+
+        public RateAggregator(TimeSpan window)
+        {
+            _window = window;
+        }
+
+        public void Add(Sample sample)
+        {
+            _samples.Add(sample);
+            Evict(sample.Timestamp);
+        }
+
+        private void Evict(DateTime now)
+        {
+            var cutoff = now - _window;
+            _samples.RemoveAll(s => s.Timestamp < cutoff);
+        }
+
+        public double Sum()
+        {
+            return _samples.Sum(s => s.Value);
+        }
+
+        public double Average()
+        {
+            if (_samples.Count == 0)
+            {
+                return 0.0;
+            }
+            return _samples.Sum(s => s.Value) / _samples.Count;
+        }
+
+        public double Percentile(int p)
+        {
+            if (_samples.Count == 0)
+            {
+                return 0.0;
+            }
+            var ordered = _samples.Select(s => s.Value).OrderBy(v => v).ToList();
+            int index = (int)Math.Ceiling(p / 100.0 * ordered.Count);
+            return ordered[index];
+        }
+
+        public int Count => _samples.Count;
+    }
+}

--- a/feature_flags.py
+++ b/feature_flags.py
@@ -1,0 +1,50 @@
+"""Percentage-based feature flag evaluator for the swell platform.
+
+Deterministically buckets users into flag variants based on a stable
+hash of the user id, so a given user always gets the same variant for
+a given flag rollout percentage.
+"""
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
+
+
+@dataclass
+class Flag:
+    key: str
+    enabled: bool
+    rollout_percent: int  # 0..100
+    allowlist: List[str] = field(default_factory=list)
+
+
+class FeatureFlagEvaluator:
+    def __init__(self):
+        self._flags: Dict[str, Flag] = {}
+
+    def upsert(self, flag: Flag) -> None:
+        self._flags[flag.key] = flag
+
+    def _bucket(self, flag_key: str, user_id: str) -> int:
+        """Return a stable bucket in [0, 100) for this user/flag pair."""
+        digest = hashlib.sha256(f"{flag_key}:{user_id}".encode()).hexdigest()
+        return int(digest, 16) % 100
+
+    def is_enabled(self, flag_key: str, user_id: str) -> bool:
+        flag = self._flags.get(flag_key)
+        if flag is None or not flag.enabled:
+            return False
+        if user_id in flag.allowlist:
+            return True
+        bucket = self._bucket(flag_key, user_id)
+        return bucket <= flag.rollout_percent
+
+    def variants_for(self, user_id: str) -> Dict[str, bool]:
+        """Evaluate every registered flag for a user."""
+        return {
+            key: self.is_enabled(key, user_id)
+            for key in self._flags
+        }
+
+    def rollout_summary(self) -> Dict[str, int]:
+        return {key: flag.rollout_percent for key, flag in self._flags.items()}


### PR DESCRIPTION

<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Add deterministic feature flag evaluator and time-windowed rate aggregator for Swell platform metrics and flag management.

Main changes:
- Implemented FeatureFlagEvaluator with stable SHA256-based user bucketing, allowlist support, and rollout percentage controls
- Created RateAggregator with sliding time window for computing sum, average, and percentile statistics on samples

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
